### PR TITLE
Add route /crud to execute sql statements on html page

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,16 @@ Content-Length: 370
 ```
 See https://github.com/rcjberlin/rcj-dss#evaluation for more details.
 
+## API v2
+Each POST request needs to have the object referee with name and auth (when authentication is required).
+```
+{
+    referee: {
+        name: "NL",
+        auth: "wbSwFU6tY1c"
+    },
+    ...
+}
+```
+
+The response is always a JSON.

--- a/public/crud.html
+++ b/public/crud.html
@@ -6,11 +6,20 @@
         <title>rcj-server - CRUD</title>
 
         <!--<link rel="stylesheet" href="./style.css">-->
-        <script src="main.js" type="text/javascript" defer></script>
+        <script src="./crud/main.js" type="text/javascript" defer></script>
+        <style>
+            table {
+                border-collapse: collapse;
+            }
+            tr, td {
+                padding: 0.1em 0.5em;
+                border: 1px solid #ccc;
+            }
+        </style>
     </head>
 
     <body>
-        <div style="width: 100%; max-width: 800px; background: #eee; margin: auto; padding: 1vw;">
+        <div style="width: 95vw; max-width: 1200px; background: #eee; margin: auto; padding: 1vw;">
             <form>
                 <h1>rcj-server - CRUD</h1>
                 <p>Instead of searching for vulnerabilities, you can enter your SQL injection directly here...</p>
@@ -19,7 +28,7 @@
                     <input type="password" id="password" placeholder="Password" />
                 </div>
                 <div style="margin-top: 1vw;">
-                    <textarea id="sql-statement" style="width: 100%; resize: vertical;" placeholder="sql statement"></textarea>
+                    <textarea id="sql-statement" style="width: 100%; resize: vertical;" placeholder="SQL Statement"></textarea>
                 </div>
                 <div style="margin-top: 1vw;">
                     <button type="button" onclick="executeSQL()">Execute SQL Statement</button>

--- a/public/crud.html
+++ b/public/crud.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>rcj-server - CRUD</title>
+
+        <!--<link rel="stylesheet" href="./style.css">-->
+        <script src="main.js" type="text/javascript" defer></script>
+    </head>
+
+    <body>
+        <div style="width: 100%; max-width: 800px; background: #eee; margin: auto; padding: 1vw;">
+            <form>
+                <h1>rcj-server - CRUD</h1>
+                <p>Instead of searching for vulnerabilities, you can enter your SQL injection directly here...</p>
+                <div style="margin-top: 1vw;">
+                    <input type="text" id="username" placeholder="Username" />
+                    <input type="password" id="password" placeholder="Password" />
+                </div>
+                <div style="margin-top: 1vw;">
+                    <textarea id="sql-statement" style="width: 100%; resize: vertical;" placeholder="sql statement"></textarea>
+                </div>
+                <div style="margin-top: 1vw;">
+                    <button type="button" onclick="executeSQL()">Execute SQL Statement</button>
+                </div>
+                <div id="box-output" style="margin-top: 1vw;">
+                    You will see the result of your SQL statement here
+                </div>
+            </form>
+        </div>
+    </body>
+</html>

--- a/public/crud.html
+++ b/public/crud.html
@@ -15,6 +15,9 @@
                 padding: 0.1em 0.5em;
                 border: 1px solid #ccc;
             }
+            form div {
+                margin-top: 1vw;
+            }
         </style>
     </head>
 
@@ -23,17 +26,19 @@
             <form>
                 <h1>rcj-server - CRUD</h1>
                 <p>Instead of searching for vulnerabilities, you can enter your SQL injection directly here...</p>
-                <div style="margin-top: 1vw;">
+                <div>
                     <input type="text" id="username" placeholder="Username" />
                     <input type="password" id="password" placeholder="Password" />
                 </div>
-                <div style="margin-top: 1vw;">
+                <div id="schema">
+                </div>
+                <div>
                     <textarea id="sql-statement" style="width: 100%; resize: vertical;" placeholder="SQL Statement"></textarea>
                 </div>
-                <div style="margin-top: 1vw;">
+                <div>
                     <button type="button" onclick="executeSQL()">Execute SQL Statement</button>
                 </div>
-                <div id="box-output" style="margin-top: 1vw;">
+                <div id="box-output">
                     You will see the result of your SQL statement here
                 </div>
             </form>

--- a/public/main.js
+++ b/public/main.js
@@ -1,0 +1,3 @@
+function executeSQL () {
+    document.getElementById("box-output").innerText = "Still work-in-progress";
+};

--- a/public/main.js
+++ b/public/main.js
@@ -15,6 +15,8 @@ window.onload = function () {
             });
         })(elementId);
     }
+
+    showSchema();
 };
 
 function executeSQL () {
@@ -96,6 +98,48 @@ function executeSQL () {
     .catch(error => {
         console.log(error);
         boxOutput.innerText = "Error: " + error;
+    });
+};
+
+function showSchema () {
+    let boxOutput = document.getElementById("schema");
+    let sqlBody = {
+        referee: {
+            name: document.getElementById("username").value,
+            auth: document.getElementById("password").value,
+        },
+        sqlStatement: "schema",
+    };
+    fetch("/api/v2/sql", {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(sqlBody)
+    })
+    .then(response => response.json())
+    .then(json => {
+        boxOutput.innerHTML = "";
+        let p, span, txt;
+        for (let table of json[0].result) {
+            p = document.createElement("p");
+
+            for (let i=0; i<table.length; i++) {
+                span = document.createElement("span");
+                txt = table[i].split(" ")[0]
+                txt+= (i === 0 ? ": " : (i !== table.length-1 ? ", " : ""));
+                span.appendChild(document.createTextNode(txt));
+                if (i === 0) { span.style.fontWeight = "bold"; }
+                else { span.title = table[i].split(" ")[1]; }
+                p.appendChild(span);
+            }
+
+            boxOutput.appendChild(p);
+        }
+    })
+    .catch(error => {
+        console.log(error);
+        boxOutput.innerHTML = '<button type="button" onclick="showSchema()">Show Schema</button>';
     });
 };
 

--- a/public/main.js
+++ b/public/main.js
@@ -1,3 +1,112 @@
+const LS_DATA = "rcj-server-crud-data";
+let data = {};
+
+window.onload = function () {
+    loadDataFromLocalStorage();
+
+    let inputFieldsToStoreInLocalStorage = ["username", "password"];
+    for (let elementId of inputFieldsToStoreInLocalStorage) {
+        (function (elementId) {
+            if (!data[elementId]) { data[elementId] = ""; }
+            document.getElementById(elementId).value = data[elementId];
+            document.getElementById(elementId).addEventListener("input", (e) => {
+                data[elementId] = document.getElementById(elementId).value;
+                saveDataToLocalStorage();
+            });
+        })(elementId);
+    }
+};
+
 function executeSQL () {
-    document.getElementById("box-output").innerText = "Still work-in-progress";
+    let boxOutput = document.getElementById("box-output");
+    let sqlBody = {
+        referee: {
+            name: document.getElementById("username").value,
+            auth: document.getElementById("password").value,
+        },
+        sqlStatement: document.getElementById("sql-statement").value,
+    };
+    fetch("/api/v2/sql", {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(sqlBody)
+    })
+    .then(response => response.json())
+    .then(json => {
+        boxOutput.innerHTML = "";
+        let div, el, table, thead, tr;
+        if (json.error) {
+            div = document.createElement("div");
+
+            if (json.statement) {
+                el = document.createElement("h2");
+                el.appendChild(document.createTextNode(json.statement));
+                div.appendChild(el);
+            }
+
+            el = document.createElement("p");
+            el.appendChild(document.createTextNode(json.error));
+            el.style.color = "#f00";
+            div.appendChild(el);
+
+            boxOutput.appendChild(div);
+            return;
+        }
+        for (let row of json) {
+            div = document.createElement("div");
+            div.style.overflowX = "auto";
+
+            el = document.createElement("h2");
+            el.appendChild(document.createTextNode(row.statement));
+            div.appendChild(el);
+
+            if (row.result.length === 0 && row.description.length === 0) {
+                el = document.createElement("p");
+                el.appendChild(document.createTextNode("Successful"));
+                div.appendChild(el);
+            } else {
+                table = document.createElement("table");
+                thead = document.createElement("thead");
+                thead.style.fontWeight = "bold";
+                tr = document.createElement("tr");
+                for (let columnTitle of row.description) {
+                    el = document.createElement("td");
+                    el.appendChild(document.createTextNode(columnTitle));
+                    tr.appendChild(el);
+                }
+                thead.appendChild(tr);
+                table.appendChild(thead);
+
+                for (let resultRow of row.result) {
+                    tr = document.createElement("tr");
+                    for (let resultCell of resultRow) {
+                        el = document.createElement("td");
+                        el.appendChild(document.createTextNode(resultCell));
+                        tr.appendChild(el);
+                    }
+                    table.appendChild(tr);
+                }
+                div.appendChild(table);
+            }
+            boxOutput.appendChild(div);
+        }
+    })
+    .catch(error => {
+        console.log(error);
+        boxOutput.innerText = "Error: " + error;
+    });
+};
+
+let saveDataToLocalStorage = function () {
+    localStorage.setItem(LS_DATA, JSON.stringify(data));
+};
+let loadDataFromLocalStorage = function () {
+    data = localStorage.getItem(LS_DATA);
+	if (data === null) {
+		data = {};
+	} else {
+		data = JSON.parse(data);
+	}
 };

--- a/src/db.py
+++ b/src/db.py
@@ -22,6 +22,22 @@ class RcjDb:
         else:
             return rv
 
+    def _execute_statement(self, statement):
+        # split into multiple statements in case there are multiple
+        statements = [s.strip() for s in statement.replace("\n", " ").split(";")]
+        r = []
+        for statement in statements:
+            if(statement == ""): continue
+            try:
+                cur = self.db.execute(statement)
+                r.append({'statement': statement,
+                            'result': cur.fetchall(),
+                            'description': [el[0] for el in cur.description] if cur.description else []})
+            except Exception as e:
+                return {'error': str(e), 'statement': statement}
+        self.db.commit()
+        return r
+
     def create_database(self, schema_file):
         c = self.db.cursor()
         with open(schema_file) as f:

--- a/src/rcj.py
+++ b/src/rcj.py
@@ -136,6 +136,12 @@ class Rcj:
         pwhash = generate_password_hash(password)
         self.db.update_referee(username, pwhash)
 
+    def execute_sql_statement(self, statement):
+        """
+        executes the statement and returns the result (including column names)
+        """
+        return self.db._execute_statement(statement)
+
 if __name__ == '__main__':
     import fire #cli
     fire.Fire(Rcj)

--- a/src/rcj_flask.py
+++ b/src/rcj_flask.py
@@ -94,3 +94,16 @@ def get_runs():
 def get_runs_competition(competition):
     return jsonify({'runs': g.rcj.get_runs_competition(competition)})
 
+@app.route('/crud', methods=['GET'])
+def crud():
+    return send_from_directory('../public', 'crud.html')
+
+@app.route('/api/v2/sql', methods=['POST'])
+def sql():
+    # check auth, only certain users / roles?
+    # check supplied csrf token, verify, invalidate this in list of allowed tokens, create new one and send this
+    # csrf library? csrf really needed (depending on how credentials are stored and transmitted)?!
+    # execute statement and return result
+    # logging?
+    # provide schema?
+    return "in progress"


### PR DESCRIPTION
- `/crud` displays a html page where the statement can be entered and submitted, the result is displayed there too
- `/sql` is the route to exchange data for executing statements in json format, statement goes in, get's executed, result will be returned
- restricted to authorized users, only usernames `niko` and `manuel`
- see also issue #3